### PR TITLE
Chore/rollback yields api to post

### DIFF
--- a/scripts/main-yield-charts.main.v1.0.1.js
+++ b/scripts/main-yield-charts.main.v1.0.1.js
@@ -28,37 +28,31 @@ const nationalStocksYields = {
   ]
 }
 
-const BASE_URL = 'https://91o7sqo7s3.execute-api.us-east-1.amazonaws.com/prod';
+var myHeaders = new Headers();
+myHeaders.append("Content-Type", "application/json");
 
-const buildQueryString = (queryObject) => Object.entries(queryObject)
-  .filter(([_, value]) => !!value)
-  .map(([key, value]) => `${key}=${value}`)
-  .join('&');
+const DEFAULT_URL = 'https://91o7sqo7s3.execute-api.us-east-1.amazonaws.com/prod/';
 
-const buildPathBy = (portfolioType) => ({
-  harryIpsa: 'harryIpsaYields',
-  wallet: 'walletYields',
-  smart: 'recommendationYields',
-}[portfolioType]);
-
-const fetchDataApi = ({
-  portfolioType,
+const getYieldsFor = ({
   year,
   month,
   risk,
+  portfolioType,
   typeUniverse
 }) => {
-  if (portfolioType === 'harryIpsa') return nationalStocksYields; // TODO: fetch this from the API
-
-  const url = `${BASE_URL}/${buildPathBy(portfolioType)}?${buildQueryString({ year, month, risk, typeUniverse })}`
-
+  var routeParam = 'recommendationYields';
+  if (portfolioType === 'harryIpsa') return nationalStocksYields;
+  if (portfolioType === 'wallet') routeParam = 'walletYields';
+  const url = `${DEFAULT_URL}${routeParam}`;
   const requestOptions = {
-    method: 'GET',
+    method: 'POST',
+    headers: myHeaders,
+    body: JSON.stringify({ year, month, risk, typeUniverse}),
     redirect: 'follow'
   };
-
-  return fetch(url, requestOptions).then(response => response.json())
-}
+  return fetch(url, requestOptions)
+    .then(response => response.json())
+};
 
 const MOTNHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago','Sept', 'Oct', 'Nov', 'Dic']
 
@@ -102,13 +96,13 @@ const getYieldsArrayFor = async ({
   year= '2023',
   month='01',
   risk=1,
-  portfolio,
+  portfolioType,
   typeUniverse,
-}) => fetchDataApi({
+}) => getYieldsFor({
   year,
   month,
   risk,
-  portfolio,
+  portfolioType,
   typeUniverse
 }).then(mapAsDataArray);
 
@@ -272,15 +266,15 @@ const drawCharts = async (selectedPeriod = 'max') => {
   if (refreshDataPending || hasAnyEmptyDataArray()){
     refreshDataPending = false
     Promise.all([
-      getYieldsArrayFor({ portfolio: 'wallet' }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk: 2 }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk: 4 }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk: 6 }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk: 6, typeUniverse: 'techThematicUniverse' }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk: 6, typeUniverse: 'greenThematicUniverse' }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk: 6, typeUniverse: 'cryptoThematicUniverse' }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk: 1 }),
-      getYieldsArrayFor({ portfolio: 'recommendation', risk:  6})
+      getYieldsArrayFor({ portfolioType: 'wallet' }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk: 2 }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk: 4 }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk: 6 }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk: 6, typeUniverse: 'techThematicUniverse' }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk: 6, typeUniverse: 'greenThematicUniverse' }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk: 6, typeUniverse: 'cryptoThematicUniverse' }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk: 1 }),
+      getYieldsArrayFor({ portfolioType: 'recommendation', risk:  6})
       ]).then((results) => {
         dataArrays.wallet.max = results[0].length ? calculateAccumYieldsFor(results[0]) : walletAccumDefaultDataArray;
         dataArrays.wallet['1a'] = results[0].length ? calculateAccumYieldsFor(results[0], getIndexOfDataArrayBy('1a')(results[0])) : walletAccumDefaultDataArray;

--- a/scripts/update-chart.v0.0.3.js
+++ b/scripts/update-chart.v0.0.3.js
@@ -30,37 +30,31 @@ const nationalStocksYields = {
   ]
 }
 
-const BASE_URL = 'https://91o7sqo7s3.execute-api.us-east-1.amazonaws.com/prod';
+var myHeaders = new Headers();
+myHeaders.append("Content-Type", "application/json");
 
-const buildQueryString = (queryObject) => Object.entries(queryObject)
-  .filter(([_, value]) => !!value)
-  .map(([key, value]) => `${key}=${value}`)
-  .join('&');
+const DEFAULT_URL = 'https://91o7sqo7s3.execute-api.us-east-1.amazonaws.com/prod/';
 
-const buildPathBy = (portfolioType) => ({
-  harryIpsa: 'harryIpsaYields',
-  wallet: 'walletYields',
-  smart: 'recommendationYields',
-}[portfolioType]);
-
-const fetchDataApi = ({
-  portfolioType,
+const getYieldsFor = ({
   year,
   month,
   risk,
+  portfolioType,
   typeUniverse
 }) => {
-  if (portfolioType === 'harryIpsa') return nationalStocksYields; // TODO: fetch this from the API
-
-  const url = `${BASE_URL}/${buildPathBy(portfolioType)}?${buildQueryString({ year, month, risk, typeUniverse })}`
-
+  var routeParam = 'recommendationYields';
+  if (portfolioType === 'harryIpsa') return nationalStocksYields;
+  if (portfolioType === 'wallet') routeParam = 'walletYields';
+  const url = `${DEFAULT_URL}${routeParam}`;
   const requestOptions = {
-    method: 'GET',
+    method: 'POST',
+    headers: myHeaders,
+    body: JSON.stringify({ year, month, risk, typeUniverse}),
     redirect: 'follow'
   };
-
-  return fetch(url, requestOptions).then(response => response.json())
-}
+  return fetch(url, requestOptions)
+    .then(response => response.json())
+};
 
 const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago','Sept', 'Oct', 'Nov', 'Dic']
 const options = {
@@ -162,7 +156,7 @@ const updateAllYieldsInfoFor = async (
     typeUniverse
   }
 ) => {
-  const response = await fetchDataApi({ portfolioType, year, month, risk, typeUniverse });
+  const response = await getYieldsFor({ year, month, risk, portfolioType, typeUniverse });
   const yields = response.yields;
   const lastTwelveYields = yields.slice(-12);
   const lastYearYield = getTotalYield(lastTwelveYields);

--- a/scripts/update-id-selector-with-yield.v0.0.8.js
+++ b/scripts/update-id-selector-with-yield.v0.0.8.js
@@ -28,37 +28,31 @@ const nationalStocksYields = {
   ]
 }
 
-const BASE_URL = 'https://91o7sqo7s3.execute-api.us-east-1.amazonaws.com/prod';
+var myHeaders = new Headers();
+myHeaders.append("Content-Type", "application/json");
 
-const buildQueryString = (queryObject) => Object.entries(queryObject)
-  .filter(([_, value]) => !!value)
-  .map(([key, value]) => `${key}=${value}`)
-  .join('&');
+const DEFAULT_URL = 'https://91o7sqo7s3.execute-api.us-east-1.amazonaws.com/prod/';
 
-const buildPathBy = (portfolioType) => ({
-  harryIpsa: 'harryIpsaYields',
-  wallet: 'walletYields',
-  smart: 'recommendationYields',
-}[portfolioType]);
-
-const fetchDataApi = ({
-  portfolioType,
+const getYieldsFor = ({
   year,
   month,
   risk,
+  portfolioType,
   typeUniverse
 }) => {
-  if (portfolioType === 'harryIpsa') return nationalStocksYields; // TODO: fetch this from the API
-
-  const url = `${BASE_URL}/${buildPathBy(portfolioType)}?${buildQueryString({ year, month, risk, typeUniverse })}`
-
+  var routeParam = 'recommendationYields';
+  if (portfolioType === 'harryIpsa') return nationalStocksYields;
+  if (portfolioType === 'wallet') routeParam = 'walletYields';
+  const url = `${DEFAULT_URL}${routeParam}`;
   const requestOptions = {
-    method: 'GET',
+    method: 'POST',
+    headers: myHeaders,
+    body: JSON.stringify({ year, month, risk, typeUniverse}),
     redirect: 'follow'
   };
-
-  return fetch(url, requestOptions).then(response => response.json())
-}
+  return fetch(url, requestOptions)
+    .then(response => response.json())
+};
 
 const getTotalYield = (yields, key) => yields.reduce((accYield, { [key]: rentabilidadMes }) => (1 + rentabilidadMes) * accYield , 1);
 
@@ -75,12 +69,12 @@ const updateSelectorWithYields = async (
 ) => {
   document.getElementById(selectorId).textContent = '...';
 
-  const data = await fetchDataApi({
-    portfolioType,
+  const data = await getYieldsFor({
     year,
     month,
     risk,
-    typeUniverse
+    portfolioType,
+    typeUniverse,
   });
 
   const yields = data.yields;


### PR DESCRIPTION
Se ajusta el consumo de la api de harry para usar `POST`, y no `GET`, ya que el `POST` sí está trabajando con `cache`